### PR TITLE
Add basic Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:alpine
+RUN mkdir /app 
+ADD . /app/ 
+WORKDIR /app 
+RUN go build -o hello-go-web . 
+CMD ["/app/hello-go-web"]
+EXPOSE 8080


### PR DESCRIPTION
Congratulations, you’ve gone from having an 8.7MB static binary to
having a 300MB Docker image!

``` shell
> docker build -t my-golang-app .
> docker run -it --rm --publish 8080:8080 --name my-running-app my-golang-app &
> open http://localhost:8080/

```
