### PR TITLE
Capture memory usage in the status page

### DIFF
--- a/hello.go
+++ b/hello.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"flag"
 	"html/template"
 	"log"
 	"net/http"
 	"os"
+	"runtime"
 	"strings"
 )
 
@@ -153,6 +155,9 @@ func statusHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "private, no-cache, no-store, must-revalidate")
 	w.WriteHeader(http.StatusOK)
+	var mem runtime.MemStats
+	runtime.ReadMemStats(&mem)
+	json.NewEncoder(w).Encode(mem)
 }
 
 func getKeyValues() KeyValues {


### PR DESCRIPTION
Running things in Cloud Foundry means that observability isn’t quite
where we’d like it to be. `psutil` in Python doesn’t work.

This change is an experiment to see whether we get meaningful data out
of Go applications. If it succeeds, then we might be able to use a
similar mechanism (in terms of C system calls) to improve what we have
for Python applications.
