### PR TITLE
Add separate build and run Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,0 @@
-FROM golang:alpine
-RUN mkdir /app 
-ADD . /app/ 
-WORKDIR /app 
-RUN go build -o hello-go-web . 
-CMD ["/app/hello-go-web"]
-EXPOSE 8080

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,7 @@
+FROM golang:alpine
+RUN mkdir /app
+ADD Dockerfile.run hello.go /app/
+WORKDIR /app
+RUN env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o hello-go-web .
+# Output a tarball which can be piped into `docker build -f Dockerfile.run -`
+CMD tar -cf - -C /app Dockerfile.run -C /app hello-go-web

--- a/Dockerfile.run
+++ b/Dockerfile.run
@@ -1,0 +1,5 @@
+FROM joeshaw/busybox-nonroot
+EXPOSE 8080
+USER nobody
+COPY hello-go-web /bin/hello-go-web
+CMD ["/bin/hello-go-web"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+.PHONY: build
+
+build:
+	docker build -t hello-go-web-builder -f Dockerfile.build .
+	docker run --rm hello-go-web-builder | docker build -t hello-go-web -f Dockerfile.run -


### PR DESCRIPTION
This brings the runtime Docker image size down a lot, from 300MB to
13.5MB. That feels a lot better from deploying things over a network.

```sh
> make
> docker run --rm -it -p 8080:8080 hello-go-web &
> open http://localhost:8080
```

Taken from https://joeshaw.org/smaller-docker-containers-for-go-apps/